### PR TITLE
Refactor WiFi input layout to fix overflow

### DIFF
--- a/include/web/mcp2515_dashboard_ui.h
+++ b/include/web/mcp2515_dashboard_ui.h
@@ -400,10 +400,10 @@ hr{border:none;border-top:1px solid var(--bd);margin:16px}
   <div style="margin-bottom:14px">
     <div class="feat-name" style="margin-bottom:8px">WiFi Internet</div>
     <div class="feat-desc" style="margin-bottom:8px">Connect to your home WiFi for plugin downloads</div>
-    <div style="display:flex;gap:6px;margin-bottom:6px">
-      <input class="sniff-input" id="wifi-ssid" placeholder="WiFi SSID" style="flex:1">
-      <input class="sniff-input" id="wifi-pass" placeholder="Password" type="password" style="flex:1">
-      <button class="sniff-btn" onclick="saveWifi()">Connect</button>
+    <div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:6px">
+      <input class="sniff-input" id="wifi-ssid" placeholder="WiFi SSID" style="flex:1 1 180px;min-width:0">
+      <input class="sniff-input" id="wifi-pass" placeholder="Password" type="password" style="flex:1 1 180px;min-width:0">
+      <button class="sniff-btn" onclick="saveWifi()" style="flex:0 0 auto">Connect</button>
     </div>
     <div style="font-size:11px;color:var(--tx3)" id="wifi-status">Not configured</div>
   </div>


### PR DESCRIPTION
The password input & connect button overflows outside of the card container, breaking the layout.

<img width="270" height="600" alt="16922a00-debc-490c-8092-33bc6d737404" src="https://github.com/user-attachments/assets/2d5572a7-7bc8-459d-ac68-02761caa1424" />
