### PR TITLE
refactor plugins, add docs and tested community plugins

### DIFF
--- a/docs/command-kb.md
+++ b/docs/command-kb.md
@@ -1,0 +1,158 @@
+# Command Knowledge Base
+
+A place to document CAN commands we've found and tested — including ones that didn't work as expected. If you know what a signal actually does or where we got the bits wrong, please comment or open a PR.
+
+Signal positions are from the DBC corresponding to FW 2026.8.6. Results are from HW4 (Model 3 Highland, Basic Autopilot).
+
+**Checksum formula we used:**
+
+```
+byte[7] = (ID_low + ID_high + byte[0] + byte[1] + byte[2] + byte[3] + byte[4] + byte[5] + byte[6]) & 0xFF
+```
+
+Where `ID_low = CAN_ID & 0xFF` and `ID_high = (CAN_ID >> 8) & 0xFF`.
+
+Example for 0x238 (ID 568): `ID_low = 0x38`, `ID_high = 0x02`.
+
+Counter in byte[6] lower nibble: we incremented it by 1 each frame, wrapping at 15.
+
+---
+
+## 0x297 — ID 663
+
+**Signal name in DBC:** `UI_adaptiveRideRequest` — bits[4:3] of byte[0]
+
+| bits[4:3] value | Mode |
+|-----------------|------|
+| 0 | COMFORT |
+| 1 | AUTO |
+| 2 | SPORT |
+| 3 | ADVANCED |
+
+**Counter:** byte[6] lower nibble, incremented each frame  
+**Checksum:** byte[7] per formula above
+
+**What we did:** Set bits[4:3] of byte[0] to 0 (COMFORT). Incremented counter, recalculated checksum per formula above.
+
+**Result:** No visible effect.
+
+**Questions for the community:**
+- Does this frame exist on Highland (2024+)?
+- Does anyone have a CAN log showing this frame changing when switching suspension modes manually?
+
+---
+
+## 0x238 — ID 568 — Reject Bit Overrides
+
+**Counter:** byte[6] lower nibble  
+**Checksum:** byte[7] per formula above
+
+We set the following bits to 0 individually. Signal names from DBC:
+
+### bit 40 — `UI_rejectLeftLaneChange`
+
+Set to 0. No visible result.
+
+### bit 41 — `UI_rejectRightLaneChange`
+
+Set to 0. No visible result.
+
+### bit 43 — `UI_rejectNavLaneChange`
+
+Set to 0. No visible result.
+
+### bit 47 — `UI_rejectHandsOnLaneChange`
+
+Set to 0. No visible result.
+
+**Questions for the community:**
+- Are these bits actually read by DAS on HW4?
+- Are the bit positions correct for 2026 firmware?
+- Has anyone seen these bits change in a live CAN log?
+
+---
+
+## 0x238 — ID 568 — Autosteer Road Restrictions
+
+Signal names from DBC. Counter and checksum same as above.
+
+### `UI_roadClass` — bits[5:3] of byte[0]
+
+Set bits[5:3] to value 1 using `set_byte byte=0 val=8 mask=56`. No visible result.
+
+### `UI_controlledAccess` — bit 37
+
+Set to 1 using `set_bit bit=37 val=1`. No visible result.
+
+### `UI_rejectAutosteer` — bit 46
+
+Set to 0 using `set_bit bit=46 val=0`. No visible result.
+
+### `UI_autosteerRestricted` — bit 49
+
+Set to 0 using `set_bit bit=49 val=0`. No visible result.
+
+**Note:** Country Spoof (same frame, byte[2-3]) does seem to get processed — Tesla checksum on this frame appears to work with our formula. So if these bits had no effect, it may be that the signal positions in the DBC don't match our FW version.
+
+---
+
+## 0x238 — ID 568 — Country Spoof
+
+### byte[2] — `UI_countryCode` lower byte
+
+Set byte[2] = 0x9A (154) using `set_byte byte=2 val=154 mask=255`.
+
+### byte[3] — `UI_countryCode` upper bits
+
+Set bits[1:0] of byte[3] = 0x01 using `set_byte byte=3 val=1 mask=3`.
+
+Together these encode country code 410 (Korea) in bits[9:0] across bytes 2–3.
+
+**Result:** Unknown — untested in isolation. Combined as one plugin with checksum, no confirmed visual result yet.
+
+---
+
+## 0x3F8 — ID 1016 — LC Stalk Confirm
+
+**Signal:** `UI_ulcStalkConfirm` — bit 1
+
+Set to 0 using `set_bit bit=1 val=0`.
+
+**Result:** Untested.
+
+**Questions:**
+- Is bit 1 the correct position for this signal on Highland/HW4?
+- What should change visually when this works?
+
+---
+
+## 0x3F8 — ID 1016 — Hands-On Requirement
+
+**Signal:** `UI_handsOnRequirementDisable` — bit 14
+
+Set to 1 using `set_bit bit=14 val=1`.
+
+**Result:** Untested.
+
+**Questions:**
+- Is bit 14 correct on HW4?
+- Is this enforced server-side or only via CAN?
+
+---
+
+## 0x3F8 — ID 1016 — ULC Speed Config
+
+**Signal:** `UI_ulcSpeedConfig` — bits[3:2] of byte[6]
+
+Applied `and_byte byte=6 val=0xF3` to clear bits 2–3.
+
+**Result:** Untested as isolated change. Note: with ULC enabled the car already overtakes on its own — unclear if this bit changes that behavior or controls something else.
+
+**Questions:**
+- What does `UI_ulcSpeedConfig` actually control in practice?
+
+---
+
+## Contributing
+
+If you've tested any of these and got a result — or know the correct bit positions — please open a Discussion or PR. Even negative results are useful.

--- a/docs/examples/HW4/bypass-tlssc-hw4.json
+++ b/docs/examples/HW4/bypass-tlssc-hw4.json
@@ -1,15 +1,20 @@
 {
   "name": "Bypass TLSSC HW4",
-  "version": "1.0.0",
+  "version": "1.1",
   "author": "ev-open-can-tools",
+  "description": [
+    "Frame 0x3FD (ID 1021), mux 0.",
+    "set_bit bit=38 val=1: sets UI_fsdStopsControlEnabled — bypasses the TLSSC hardware requirement check.",
+    "Bits 46 and 60 were removed from this plugin for two reasons: they duplicate AD Activation HW4, and more importantly they send FSD activation commands on the CAN bus which Tesla can see — the purpose of this plugin is only to restore TLSSC, not to activate FSD.",
+    "Tested: Tesla Model 3 Highland Performance 2024, FW 2026.8.6.",
+    "After DAS reset, TLSSC option appeared in UI, was toggleable and persisted ~15 min after device disconnected."
+  ],
   "rules": [
     {
       "id": 1021,
       "mux": 0,
       "ops": [
-        { "type": "set_bit", "bit": 38, "val": 1 },
-        { "type": "set_bit", "bit": 46, "val": 1 },
-        { "type": "set_bit", "bit": 60, "val": 1 }
+        { "type": "set_bit", "bit": 38, "val": 1 }
       ]
     }
   ]

--- a/docs/examples/HW4/country-spoof-kr-hw4.json
+++ b/docs/examples/HW4/country-spoof-kr-hw4.json
@@ -1,0 +1,26 @@
+{
+  "name": "Country Spoof KR HW4",
+  "version": "1.0",
+  "author": "Christian / kp43h8",
+  "description": [
+    "Frame 0x238 (ID 568).",
+    "Spoofs UI_countryCode to Korea (410) — a 10-bit value split across two bytes:",
+    "set_byte byte=2 val=154 mask=255: sets byte[2] to 0x9A — lower 8 bits of country code 410.",
+    "set_byte byte=3 val=1 mask=3: sets bits[1:0] of byte[3] to 0b01 — upper 2 bits of country code 410.",
+    "checksum: byte[7] recalculated.",
+    "Observed behavior: if you signal first, EAP changes lanes automatically without confirmation.",
+    "If EAP initiates the overtake itself and turns on the indicator, you still need to confirm with the steering wheel.",
+    "If anyone finds a way to bypass the steering confirmation in that second case, please share.",
+    "Tested: Tesla Model 3 Highland Performance 2024, FW 2026.8.6."
+  ],
+  "rules": [
+    {
+      "id": 568,
+      "ops": [
+        { "type": "set_byte", "byte": 2, "val": 154, "mask": 255 },
+        { "type": "set_byte", "byte": 3, "val": 1,   "mask": 3   },
+        { "type": "checksum" }
+      ]
+    }
+  ]
+}

--- a/docs/examples/HW4/emergency-vehicle-detection-hw4.json
+++ b/docs/examples/HW4/emergency-vehicle-detection-hw4.json
@@ -1,15 +1,18 @@
 {
   "name": "Emergency Vehicle Detection HW4",
-  "version": "1.0.0",
+  "version": "1.1",
   "author": "ev-open-can-tools",
+  "description": [
+    "Frame 0x3FD (ID 1021), mux 0.",
+    "set_bit bit=59 val=1: sets UI_enableApproachingEmergencyVehicleDetection — enables detection of approaching emergency vehicles.",
+    "Bits 46 and 60 were removed from this plugin — anyone already running FSD has those bits active by default, so repeating them here is unnecessary."
+  ],
   "rules": [
     {
       "id": 1021,
       "mux": 0,
       "ops": [
-        { "type": "set_bit", "bit": 46, "val": 1 },
-        { "type": "set_bit", "bit": 59, "val": 1 },
-        { "type": "set_bit", "bit": 60, "val": 1 }
+        { "type": "set_bit", "bit": 59, "val": 1 }
       ]
     }
   ]

--- a/docs/examples/HW4/nag-suppression-hw4.json
+++ b/docs/examples/HW4/nag-suppression-hw4.json
@@ -1,14 +1,18 @@
 {
   "name": "Nag Suppression HW4",
-  "version": "1.0.0",
+  "version": "1.1",
   "author": "ev-open-can-tools",
+  "description": [
+    "Frame 0x3FD (ID 1021), mux 1.",
+    "set_bit bit=19 val=0: clears UI_applyEceR79 — disables enforcement of ECE R79, the European regulation that mandates hands-on-wheel detection and warning during autosteer.",
+    "ECE R79 also limits lateral acceleration during autosteer to 3 m/s² (~0.3g) — disabling it removes this cornering limit, so the car no longer slows down or shows 'Autopilot limited' on tighter bends."
+  ],
   "rules": [
     {
       "id": 1021,
       "mux": 1,
       "ops": [
-        { "type": "set_bit", "bit": 19, "val": 0 },
-        { "type": "set_bit", "bit": 47, "val": 1 }
+        { "type": "set_bit", "bit": 19, "val": 0 }
       ]
     }
   ]

--- a/docs/examples/HW4/summon-eu-unlock-hw4.json
+++ b/docs/examples/HW4/summon-eu-unlock-hw4.json
@@ -1,13 +1,16 @@
 {
   "name": "Summon EU Unlock HW4",
-  "version": "1.0.0",
+  "version": "1.1",
   "author": "ev-open-can-tools",
+  "description": [
+    "Frame 0x3FD (ID 1021), mux 1.",
+    "set_bit bit=47 val=1: sets UI_hardCoreSummon — enables hardcore summon mode, unlocking summon functionality in regions where it is restricted."
+  ],
   "rules": [
     {
       "id": 1021,
       "mux": 1,
       "ops": [
-        { "type": "set_bit", "bit": 19, "val": 0 },
         { "type": "set_bit", "bit": 47, "val": 1 }
       ]
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Documentation
 
-[Project Home](../) | [Dashboard Guide](dashboard.md) | [Build & Flash](building.md) | [Plugin System](plugins.md) | [Release Notes](../CHANGELOG.md)
+[Project Home](../) | [Dashboard Guide](dashboard.md) | [Build & Flash](building.md) | [Plugin System](plugins.md) | [Command KB](command-kb.md) | [Wishlist](wishlist.md) | [Release Notes](../CHANGELOG.md)
 
 This section backs the GitHub Pages site for the project and collects the living documentation for setup, runtime dashboard use, and the plugin system.
 
@@ -9,6 +9,8 @@ This section backs the GitHub Pages site for the project and collects the living
 - [Dashboard Guide](dashboard.md) explains every major dashboard card, what is persisted, and which functions are ESP32-only
 - [Build & Flash](building.md) covers supported PlatformIO environments, profile selection, and first-boot flow
 - [Plugin System](plugins.md) documents the JSON format, install paths, limits, examples, and dashboard workflow
+- [Command KB](command-kb.md) — community knowledge base: CAN commands we've tested, bit positions, and open questions
+- [Wishlist](wishlist.md) — mods we want to see, research areas, and things that didn't work yet
 - [Release Notes](../CHANGELOG.md) tracks shipped features and fixes per version
 
 ## Documentation Map

--- a/docs/wishlist.md
+++ b/docs/wishlist.md
@@ -1,0 +1,29 @@
+# Community Wishlist
+
+A place to collect mods we want to see. If you have ideas or know how to implement something on the list — open a PR or drop a comment in Discussions.
+
+---
+
+## Adaptive Suspension Manual Override (M3 Performance)
+
+**Hardware:** Model 3 Performance (Highland), HW4  
+**Status:** 🔬 Research needed
+
+The adaptive suspension logic on the M3 Performance makes poor decisions — Sport engages at the wrong times, and there's no reliable way to lock it to a specific mode.
+
+**What we want:** Force a specific suspension setting (e.g. always Comfort).
+
+**What we tried:** Modifying `UI_adaptiveRideRequest` bits[4:3] in frame 0x297 (ID 663, `UI_suspensionControl`). Values: 0=COMFORT, 1=AUTO, 2=SPORT, 3=ADVANCED. The frame uses a counter in byte[6] lower nibble and a Tesla checksum in byte[7].
+
+**Result:** No visible effect. Possible reasons:
+- Frame 0x297 may not exist or be structured differently on Highland
+- The correct frame might be elsewhere (chassis CAN?)
+- Checksum or counter logic incorrect
+
+If you know which frame/signal actually controls adaptive suspension on Highland/HW4, please share.
+
+---
+
+## More ideas welcome
+
+Open a Discussion or PR to add to this list.


### PR DESCRIPTION
- Split nag suppression and summon EU unlock (were identical, now separate)
- Remove duplicate bits 46/60 from bypass-tlssc and emergency-vehicle-detection
- Add descriptions to all HW4 plugins explaining what each bit does and why
- Add to bypass-tlssc-hw4: tested on M3 Highland Performance 2024 FW 2026.8.6
- Add country-spoof-kr-hw4: tested, EAP lane change behavior documented
- Add docs/command-kb.md: CAN commands we tested with bit positions and open questions
- Add docs/wishlist.md: adaptive suspension research request
- Update docs/index.md: add links to new docs

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes -->

-

## Checklist

This PR adds tested community plugins and new documentation pages. No firmware code was changed — all changes are JSON plugin files and markdown docs only.
