### PR TITLE
ESP32S2 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,14 @@ jobs:
             artifact_name: firmware-esp32
             artifact_path: .pio/build/esp32_twai/firmware.bin
             extra_python_packages: littlefs-python fatfs-ng pyyaml
+
+          - env: esp32s2_twai
+            profile: --driver DRIVER_TWAI --vehicle HW4 --enable EMERGENCY_VEHICLE_DETECTION
+              --enable ENHANCED_AUTOPILOT
+            artifact_name: firmware-esp32s2
+            artifact_path: .pio/build/esp32s2_twai/firmware.bin
+            extra_python_packages: littlefs-python fatfs-ng pyyaml
+            
           - env: m5stack-atomic-can-base
             profile: --driver DRIVER_TWAI --vehicle HW4 --enable EMERGENCY_VEHICLE_DETECTION
               --enable ENHANCED_AUTOPILOT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,7 @@ jobs:
             release-assets/firmware-m5stack.bin
             release-assets/firmware-esp32-featherwing.bin
             release-assets/firmware-esp32-ext-mcp2515.bin
+            release-assets/firmware-esp32s2.bin
       - name: Publish draft release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,8 +41,6 @@ build_flags =
     -DDASH_DEFAULT_HW=1
     -std=gnu++17
 build_unflags = -std=gnu++11
-board_build.partitions = partitions_4mb_ota_1536k.csv
-monitor_speed = 115200
 
 board_build.partitions = partitions_4mb_ota_1536k.csv
 monitor_speed = 115200

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,6 +28,22 @@ build_flags =
     -DDASH_DEFAULT_HW=1
     -std=gnu++17
 build_unflags = -std=gnu++11
+
+[env:esp32s2_twai]
+platform = espressif32
+board = esp32-s2-saola-1
+framework = arduino
+extra_scripts = pre:scripts/platformio_sync_profile.py
+lib_deps = bblanchon/ArduinoJson@^7
+build_flags =
+    -DDRIVER_TWAI
+    -DESP32_DASHBOARD
+    -DDASH_DEFAULT_HW=1
+    -std=gnu++17
+build_unflags = -std=gnu++11
+board_build.partitions = partitions_4mb_ota_1536k.csv
+monitor_speed = 115200
+
 board_build.partitions = partitions_4mb_ota_1536k.csv
 monitor_speed = 115200
 

--- a/platformio_profile.h
+++ b/platformio_profile.h
@@ -1,5 +1,5 @@
 #pragma once
-
+ 
 // Shared PlatformIO profile.
 // Edit this file from the repository root before building.
 

--- a/platformio_profile.h
+++ b/platformio_profile.h
@@ -7,12 +7,12 @@
 // Uncomment ONE of the following lines to match your board:
 // #define DRIVER_MCP2515           // Adafruit Feather RP2040 CAN (MCP2515 over SPI)
 // #define DRIVER_SAME51            // Adafruit Feather M4 CAN Express (native ATSAME51 CAN)
-// #define DRIVER_TWAI // ESP32 boards with built-in TWAI (CAN) peripheral
+#define DRIVER_TWAI // ESP32 boards with built-in TWAI (CAN) peripheral
 // #define DRIVER_ESP32_EXT_MCP2515 // ESP32-S3 + external MCP2515 via SPI (use esp32_ext_mcp2515 env)
 
 // ── VEHICLE HARDWARE SELECTION ───────────────────────────────────
 // Uncomment ONE of the following lines to match your vehicle:
-// #define LEGACY // HW3-retrofit
+#define LEGACY // HW3-retrofit
 // #define HW3 // HW3
 // #define HW4    // HW4
 

--- a/platformio_profile.h
+++ b/platformio_profile.h
@@ -1,5 +1,5 @@
 #pragma once
- 
+
 // Shared PlatformIO profile.
 // Edit this file from the repository root before building.
 

--- a/platformio_profile.h
+++ b/platformio_profile.h
@@ -7,12 +7,12 @@
 // Uncomment ONE of the following lines to match your board:
 // #define DRIVER_MCP2515           // Adafruit Feather RP2040 CAN (MCP2515 over SPI)
 // #define DRIVER_SAME51            // Adafruit Feather M4 CAN Express (native ATSAME51 CAN)
-#define DRIVER_TWAI // ESP32 boards with built-in TWAI (CAN) peripheral
+// #define DRIVER_TWAI // ESP32 boards with built-in TWAI (CAN) peripheral
 // #define DRIVER_ESP32_EXT_MCP2515 // ESP32-S3 + external MCP2515 via SPI (use esp32_ext_mcp2515 env)
 
 // ── VEHICLE HARDWARE SELECTION ───────────────────────────────────
 // Uncomment ONE of the following lines to match your vehicle:
-#define LEGACY // HW3-retrofit
+// #define LEGACY // HW3-retrofit
 // #define HW3 // HW3
 // #define HW4    // HW4
 


### PR DESCRIPTION
## Summary

<!-- Adds ESP32 S2 support -->

## Change 1: Add ESP32-S2 environment to platformio.ini (at end of ESP32 TWAI section)
## Change 2: Add ESP32-S2 to the build matrix in .github/workflows/release.yml
## Change 3: Add ESP32-S2 build to files section in .github/workflows/release.yml

<!-- List the key changes -->

-

## Checklist

- [x] Code compiles for all affected board environments
- [ ] Tests pass (`pio test -e native`)
- [ ] Linter passes (`clang-format --dry-run --Werror --style=file`)
- [ ] `CHANGELOG.md` updated for relevant user-facing or tooling changes
- [ ] Documentation updated in `docs-site/docs/` (if user-facing change)
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (if user-facing or behavioral change)
- [ ] Firmware compatibility notes updated (if behavior changes per firmware version)
