### PR TITLE
Update PR target instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+## Target branch
+
+- [ ] This PR targets `dev`. Do not open feature or fix PRs directly against `main`.
+
 ## Summary
 
 <!-- Brief description of what this PR does -->


### PR DESCRIPTION
## Summary

Add a clear PR template checkbox requiring feature and fix PRs to target `dev` instead of `main`.

## Tests

Not run; markdown-only change.