### PR TITLE
Add ESP32-C6 (esp32c6_twai) PlatformIO env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,13 @@ jobs:
             artifact_name: firmware-esp32s2
             artifact_path: .pio/build/esp32s2_twai/firmware.bin
             extra_python_packages: littlefs-python fatfs-ng pyyaml intelhex
+          - env: esp32c6_twai
+            profile: --driver DRIVER_TWAI --vehicle HW4 --enable EMERGENCY_VEHICLE_DETECTION
+              --enable ENHANCED_AUTOPILOT
+            project_dir: .
+            artifact_name: firmware-esp32c6
+            artifact_path: .pio/build/esp32c6_twai/firmware.bin
+            extra_python_packages: littlefs-python fatfs-ng pyyaml intelhex
             
           - env: lilygo_tcan485_hw3
             profile: --driver DRIVER_TWAI --vehicle HW3 --enable EMERGENCY_VEHICLE_DETECTION
@@ -162,6 +169,7 @@ jobs:
             release-assets/firmware-esp32-featherwing.bin
             release-assets/firmware-esp32-ext-mcp2515.bin
             release-assets/firmware-esp32s2.bin
+            release-assets/firmware-esp32c6.bin
             release-assets/firmware-lilygo-tcan485-hw3.bin
             release-assets/firmware-m5stack-atoms3-mini.bin
             release-assets/firmware-waveshare-esp32-s3.bin

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,6 +99,11 @@ jobs:
               --enable ENHANCED_AUTOPILOT
             project_dir: .
             extra_python_packages: littlefs-python fatfs-ng pyyaml intelhex
+          - env: esp32c6_twai
+            profile: --driver DRIVER_TWAI --vehicle HW4 --enable EMERGENCY_VEHICLE_DETECTION
+              --enable ENHANCED_AUTOPILOT
+            project_dir: .
+            extra_python_packages: littlefs-python fatfs-ng pyyaml intelhex
           - env: lilygo_tcan485_hw3
             profile: --driver DRIVER_TWAI --vehicle HW3 --enable EMERGENCY_VEHICLE_DETECTION
               --enable ENHANCED_AUTOPILOT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ESP32-C6 support via the new `esp32c6_twai` PlatformIO environment (ESP-IDF, `DRIVER_TWAI` on GPIO5/GPIO4, `partitions_4mb_ota_1536k.csv`). Added to the Tests CI matrix and the Release workflow so automation builds and OTA release assets include the C6 board.
+
 ## [3.0.2-beta.3] - 2026-06-12
 
 ### Fixed

--- a/docs/building.md
+++ b/docs/building.md
@@ -11,6 +11,7 @@ The project is PlatformIO-only. Pick the correct board environment in `platformi
 | `feather_rp2040_can` | Adafruit Feather RP2040 CAN | MCP2515-based build, no web dashboard |
 | `feather_m4_can` | Adafruit Feather M4 CAN Express | Native CAN build, no web dashboard |
 | `esp32_twai` | Generic ESP32 dev board | TWAI dashboard build |
+| `esp32c6_twai` | ESP32-C6 DevKitC-1 | TWAI dashboard build (single-core RISC-V); TWAI on GPIO5/GPIO4 |
 | `lilygo_tcan485_hw3` | LILYGO TCAN485 | TWAI dashboard build with board-specific default pins |
 | `m5stack-atomic-can-base` | M5Stack Atom CAN Base | TWAI dashboard build with RGB status LED |
 | `m5stack-atoms3-mini-can-base` | M5Stack AtomS3 Mini CAN Base | TWAI dashboard build with RGB status LED and built-in injection toggle button |

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,6 +2,7 @@
 default_envs =
     esp32_twai
     esp32s2_twai
+    esp32c6_twai
     esp32_feather_v2_mcp2515
     lilygo_tcan485_hw3
     m5stack-atomic-can-base
@@ -41,6 +42,27 @@ build_flags =
     -std=gnu++17
 build_unflags = -std=gnu++11
 
+board_build.partitions = partitions_4mb_ota_1536k.csv
+monitor_speed = 115200
+
+; ESP32-C6 DevKitC-1 + external CAN transceiver (e.g. SN65HVD230).
+; Single-core RISC-V; ESP-IDF has native C6 support (no Arduino fork needed).
+; Wiring: GPIO5 = TWAI TX, GPIO4 = TWAI RX (matches the user's existing setup).
+[env:esp32c6_twai]
+platform = ${espidf6.platform}
+platform_packages = ${espidf6.platform_packages}
+board = esp32-c6-devkitc-1
+framework = espidf
+extra_scripts = pre:scripts/platformio_sync_profile.py
+lib_deps = bblanchon/ArduinoJson@^7
+build_flags =
+    -DDRIVER_TWAI
+    -DESP32_DASHBOARD
+    -DTWAI_TX_PIN=GPIO_NUM_5
+    -DTWAI_RX_PIN=GPIO_NUM_4
+    -DREC_CAP=5000
+    -std=gnu++17
+build_unflags = -std=gnu++11
 board_build.partitions = partitions_4mb_ota_1536k.csv
 monitor_speed = 115200
 


### PR DESCRIPTION
Adds an `esp32c6_twai` PlatformIO environment for the ESP32-C6 DevKitC-1 and wires it into the Tests and Release workflows.

## Target branch

- [x] This PR targets `dev`. Do not open feature or fix PRs directly against `main`.

## Summary

Adds ESP32-C6 support. ESP-IDF has native ESP32-C6 support, so no Arduino platform fork is needed — the environment follows the existing `esp32s2_twai` pattern.

## Changes

- New `[env:esp32c6_twai]` in `platformio.ini` (board `esp32-c6-devkitc-1`, `framework = espidf`, `DRIVER_TWAI` on GPIO5/GPIO4, `partitions_4mb_ota_1536k.csv`), and added to `default_envs`.
- `tests.yml`: `esp32c6_twai` added to the `platformio-build` matrix so CI builds/validates the env on PRs.
- `release.yml`: matrix entry + `firmware-esp32c6` artifact + `firmware-esp32c6.bin` added to the release asset list (automation builds + OTA).
- `docs/building.md`: added to the supported-environments table.
- `CHANGELOG.md`: noted under `[Unreleased]`.

## Checklist

- [x] Code compiles for all affected board environments (built locally on the C6: Flash 74.8% — 1.18 MB of the 1.5 MB app partition, RAM 53.5%)
- [x] Tests pass (`pio test -e native`)
- [x] Linter passes (`clang-format` — no C/C++ files changed)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Documentation updated in `docs/building.md`
- [ ] Firmware compatibility notes updated — N/A (new board only, no behavior change)
